### PR TITLE
Created books authorizations

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -24,6 +24,11 @@ class BooksController < ApplicationController
 
 	def create
 		@book = Book.new(book_params)
+
+		if !user_signed_in? || !current_user.admin
+			redirect_to books_path
+		end
+
 		if @book.save
 			redirect_to '/books'
 		else
@@ -62,6 +67,11 @@ class BooksController < ApplicationController
 
 	def update
 		@book = Book.find(params[:id])
+
+		if(!user_signed_in? || (!current_user.admin && current_user.name != @book.author)) 
+			redirect_to books_path
+		end
+
 		if @book.update(book_params)
 			redirect_to "/books/#{@book.id}"
 		else
@@ -72,6 +82,11 @@ class BooksController < ApplicationController
 
 	def destroy
 		@book = Book.find(params[:id])
+
+		if(!user_signed_in? || (!current_user.admin && current_user.name != @book.author)) 
+			redirect_to books_path
+		end
+
 		@book.destroy
 		redirect_to "/books"
 	end

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,5 +1,7 @@
 class BooksController < ApplicationController
 
+	include SessionsHelper
+
 	before_action :set_book, only: [:show, :edit, :update, :destroy]
 	before_action :deny_access_for_non_authors, only: [:edit, :update, :destroy]
 	before_action :deny_access_for_non_admin, only: [:create, :new]
@@ -9,7 +11,6 @@ class BooksController < ApplicationController
 	# before_action :deny_access_for_non_signed_in_users
 
 	def index
-
 		@title = "Books"
 		@books = Book.all
 
@@ -80,7 +81,7 @@ class BooksController < ApplicationController
 		end
 
 		def deny_access_for_non_admin
-			if !user_signed_in? || !current_user.admin
+			if !admin?
 				redirect_to books_path
 			end
 		end

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,7 +1,7 @@
 class BooksController < ApplicationController
 
 	# This runs before every method call. Checks if user is signed in
-	before_action :deny_access_for_non_signed_in_users
+	# before_action :deny_access_for_non_signed_in_users
 
 	def index
 
@@ -13,6 +13,13 @@ class BooksController < ApplicationController
 	def new
 		@title = "New Book"
 		@book = Book.new
+
+		# This if block is to disallow users to reach the new 
+		# page if they arent logged in or an admin
+		if !user_signed_in? || !current_user.admin 
+			redirect_to books_path
+		end	
+
 	end
 
 	def create
@@ -46,6 +53,11 @@ class BooksController < ApplicationController
 	def edit
 		@title = "Edit Book"
 		@book = Book.find(params[:id])
+
+		if(!user_signed_in? || (!current_user.admin && current_user.name != @book.author)) 
+			redirect_to books_path
+		end
+
 	end
 
 	def update
@@ -67,7 +79,7 @@ class BooksController < ApplicationController
 
 	private 
 
-		def book_params
+	def book_params
 			#  whitelisting params(strong params)
 			params.require(:book).permit(:title, :author, :published_year, :image_url)
 		end
@@ -78,4 +90,4 @@ class BooksController < ApplicationController
 			end
 		end
 
-end
+	end

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,5 +1,10 @@
 class BooksController < ApplicationController
 
+	before_action :set_book, only: [:show, :edit, :update, :destroy]
+	before_action :deny_access_for_non_authors, only: [:edit, :update, :destroy]
+	before_action :deny_access_for_non_admin, only: [:create, :new]
+
+
 	# This runs before every method call. Checks if user is signed in
 	# before_action :deny_access_for_non_signed_in_users
 
@@ -13,21 +18,10 @@ class BooksController < ApplicationController
 	def new
 		@title = "New Book"
 		@book = Book.new
-
-		# This if block is to disallow users to reach the new 
-		# page if they arent logged in or an admin
-		if !user_signed_in? || !current_user.admin 
-			redirect_to books_path
-		end	
-
 	end
 
 	def create
 		@book = Book.new(book_params)
-
-		if !user_signed_in? || !current_user.admin
-			redirect_to books_path
-		end
 
 		if @book.save
 			redirect_to '/books'
@@ -39,38 +33,13 @@ class BooksController < ApplicationController
 
 	def show
 		@title = "Books Show"
-		@book = Book.find(params[:id])
-
-		# random number list to populate 5 'related' books under product
-		# array is populated with 5 unique random numbers used to find id from DB
-		@randomNumArray = [] 
-		i = 0 # counter to determine when 5 numbers have been added to array
-		largestId = Book.last.id
-		# while i < 5 do  
-		# 	randNum = rand(1..largestId)
-		# 	if(!@randomNumArray.include? randNum) # ensures that the number isnt in the array
-		# 		@randomNumArray[i] = randNum
-		# 		i += 1;
-		# 	end
-		# end
 	end
 
 	def edit
 		@title = "Edit Book"
-		@book = Book.find(params[:id])
-
-		if(!user_signed_in? || (!current_user.admin && current_user.name != @book.author)) 
-			redirect_to books_path
-		end
-
 	end
 
 	def update
-		@book = Book.find(params[:id])
-
-		if(!user_signed_in? || (!current_user.admin && current_user.name != @book.author)) 
-			redirect_to books_path
-		end
 
 		if @book.update(book_params)
 			redirect_to "/books/#{@book.id}"
@@ -81,11 +50,6 @@ class BooksController < ApplicationController
 	end
 
 	def destroy
-		@book = Book.find(params[:id])
-
-		if(!user_signed_in? || (!current_user.admin && current_user.name != @book.author)) 
-			redirect_to books_path
-		end
 
 		@book.destroy
 		redirect_to "/books"
@@ -94,7 +58,7 @@ class BooksController < ApplicationController
 
 	private 
 
-	def book_params
+		def book_params
 			#  whitelisting params(strong params)
 			params.require(:book).permit(:title, :author, :published_year, :image_url)
 		end
@@ -104,5 +68,22 @@ class BooksController < ApplicationController
 				redirect_to root_path
 			end
 		end
+
+		def set_book
+			@book = Book.find(params[:id])
+		end
+
+		def deny_access_for_non_authors
+			if(!user_signed_in? || (!current_user.admin && current_user.name != @book.author)) 
+				redirect_to books_path
+			end
+		end
+
+		def deny_access_for_non_admin
+			if !user_signed_in? || !current_user.admin
+				redirect_to books_path
+			end
+		end
+
 
 	end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,0 +1,7 @@
+module SessionsHelper
+
+	def admin?
+		user_signed_in? && current_user.admin
+	end
+
+end

--- a/app/models/author_book.rb
+++ b/app/models/author_book.rb
@@ -1,0 +1,4 @@
+class AuthorBook < ApplicationRecord
+  belongs_to :author
+  belongs_to :book
+end

--- a/app/views/books/_form.html.erb
+++ b/app/views/books/_form.html.erb
@@ -15,7 +15,7 @@
 	<%= f.label(:title) %><br>
 	<%= f.text_field(:title) %> <br>
 	<%= f.label(:author) %> <br>
-	<%= f.text_field(:author) %> <br>
+	<%= f.collection_select(:author, User.all, :name, :name, :prompt => true) %> <br>
 	<%= f.label(:published_year) %> <br>
 	<%= f.text_field(:published_year) %> <br>
 	<%= f.label(:image_url) %> <br>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -15,7 +15,11 @@
             <!-- </ul> -->
             <!--END filtering-nav-->          	
 
-            <%= link_to "Add New Book", "/books/new", class: "btn-dark-add-book" %>
+            <% if user_signed_in? %>
+              <% if current_user.admin %>
+                <%= link_to "Add New Book", "/books/new", class: "btn-dark-add-book" %>
+              <% end %>
+            <% end %>
 
             <div class="portfolio-container">
             	<ul>
@@ -28,13 +32,13 @@
 
             				<div class="book-cover-container">
             					<%= book.image_url.present? ? image_tag(book.image_url, height: '238', width: '160') : image_tag("no_image_found.jpg", height: '238', width: '160') %>
-            					<%= link_to "View Details", "/books/#{book.id}", class: "view-details" %>
+            					<%= link_to "View Details", book_path(book.id), class: "view-details" %>
             				</div>
 
             				<!-- </a> -->
             			</p>
             			<h4 class="book-author">
-            				<%= link_to book.title, "#" %>
+            				<%= link_to book.title, book_path(book.id) %>
             			</h4>
             			<p class="book-author">
             				<%= book.author %>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -4,21 +4,11 @@
 <body>
 	<div class="container">
 		<div id="portfolio">
-			<!-- <ul id="filterable"> -->
-				<!-- <li class="first"><h5>Sort by:</h5></li> -->
-				<!-- <li class="current"><a class="all" href="#all">Create New Book</a></li> -->
-            <!-- <li><a class="new" href="#new">New</a></li>
-            <li><a class="fiction" href="#fiction">Fiction</a></li>
-            <li><a class="non-fiction" href="#non-fiction">Non-Fiction</a></li>
-            <li><a class="all" href="#popular">Popular</a></li> -->
 
-            <!-- </ul> -->
-            <!--END filtering-nav-->          	
 
-            <% if user_signed_in? %>
-              <% if current_user.admin %>
+            <% if admin? %>
+
                 <%= link_to "Add New Book", "/books/new", class: "btn-dark-add-book" %>
-              <% end %>
             <% end %>
 
             <div class="portfolio-container">
@@ -30,28 +20,28 @@
             			<p>
             				<!-- <a href="#"> -->
 
-            				<div class="book-cover-container">
-            					<%= book.image_url.present? ? image_tag(book.image_url, height: '238', width: '160') : image_tag("no_image_found.jpg", height: '238', width: '160') %>
-            					<%= link_to "View Details", book_path(book.id), class: "view-details" %>
-            				</div>
+                                <div class="book-cover-container">
+                                   <%= book.image_url.present? ? image_tag(book.image_url, height: '238', width: '160') : image_tag("no_image_found.jpg", height: '238', width: '160') %>
+                                   <%= link_to "View Details", book_path(book.id), class: "view-details" %>
+                               </div>
 
-            				<!-- </a> -->
-            			</p>
-            			<h4 class="book-author">
-            				<%= link_to book.title, book_path(book.id) %>
-            			</h4>
-            			<p class="book-author">
-            				<%= book.author %>
-            			</p>
-            		</li>
-            		<% end %>
+                               <!-- </a> -->
+                           </p>
+                           <h4 class="book-author">
+                            <%= link_to book.title, book_path(book.id) %>
+                        </h4>
+                        <p class="book-author">
+                            <%= book.author %>
+                        </p>
+                    </li>
+                    <% end %>
 
-            	</ul>
-            		<!--END ul-->
-            	</div>
+                </ul>
+                <!--END ul-->
+            </div>
 
 
-            	<!--END portfolio-wrap-->
+            <!--END portfolio-wrap-->
         </div>
         <br clear="both">
         <br clear="both">

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -15,9 +15,14 @@
           non semper nisi vulputate sed. Sed ut dui convallis, maximus nibh rutrum, tincidunt arcu.
         </p>
         
-        <%= link_to "Add to Cart", "/books/#{@book.id}#" %> <br>
-        <%= link_to "Edit", "/books/#{@book.id}/edit" %> <br>
-        <%= link_to "Delete", "/books/#{@book.id}", {method: :delete, data: {confirm: "Are you sure you want to delete #{@book.title}?"}} %> <br>
+        <% if user_signed_in? %>
+          <% if current_user.name == @book.author || current_user.admin %>
+            <%= link_to "Edit", "/books/#{@book.id}/edit" %> <br>
+          <% end %>
+          <% if current_user.admin %>
+            <%= link_to "Delete", "/books/#{@book.id}", {method: :delete, data: {confirm: "Are you sure you want to delete #{@book.title}?"}} %> <br>
+          <% end %>
+        <% end %>
         
 
       </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -4,7 +4,7 @@
 	<thead>
 		<tr>
 			<th>User</th>
-			<th>Password</th>
+			<th>Email</th>
 			<th>Age</th>
 			<th>Gender</th>
 			<th>View Details</th>

--- a/db/migrate/20190123160921_create_author_books.rb
+++ b/db/migrate/20190123160921_create_author_books.rb
@@ -1,0 +1,10 @@
+class CreateAuthorBooks < ActiveRecord::Migration[5.2]
+  def change
+    create_table :author_books do |t|
+      t.references :author, foreign_key: true
+      t.references :book, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_12_160139) do
+ActiveRecord::Schema.define(version: 2019_01_23_160921) do
+
+  create_table "author_books", force: :cascade do |t|
+    t.integer "author_id"
+    t.integer "book_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["author_id"], name: "index_author_books_on_author_id"
+    t.index ["book_id"], name: "index_author_books_on_book_id"
+  end
 
   create_table "blog_posts", force: :cascade do |t|
     t.string "title"

--- a/test/fixtures/author_books.yml
+++ b/test/fixtures/author_books.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  author: one
+  book: one
+
+two:
+  author: two
+  book: two

--- a/test/models/author_book_test.rb
+++ b/test/models/author_book_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class AuthorBookTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Currently the feature of only authors being allowed to edit is implemented through checking the authors name with the current users. (See line 57 of books_controller)
This is a temporary solution but is to be fixed in another pull request to compare id instead. I did not want to add too much to this branch in terms of migrations since I had the other parts of this issue implemented.
Currently if two authors have the exact same name they can edit each others books. 
